### PR TITLE
fix: add padding on unbalanced leading/trailing

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,7 +3,7 @@ name:                   Pull Request
 on:
   pull_request:
     branches:           [main]
-    types:              [opened, synchronize, closed]
+    types:              [opened, synchronize]
 
 jobs:
   # pull request-sepcific steps.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,24 +2,24 @@ name:                        Release
 
 on:
   push:
-    branches:               [main]
+    branches:                [main]
 
 jobs:
   # lint code.
   lint:
-    name:               Lint
-    runs-on:            ubuntu-latest
+    name:                    Lint
+    runs-on:                 ubuntu-latest
 
     steps:
-      - name:           Checkout
-        uses:           actions/checkout@v3
+      - name:                Checkout
+        uses:                actions/checkout@v3
       # only lint on actual code changes.
-      - name:           Lint
-        uses:           norio-nomura/action-swiftlint@3.2.1
+      - name:                Lint
+        uses:                norio-nomura/action-swiftlint@3.2.1
         env:
-          DIFF_BASE:    ${{ github.event.push.before }}
+          DIFF_BASE:         ${{ github.event.push.before }}
         with:
-          args:         --strict
+          args:              --strict
 
   # build the library.
   build:
@@ -49,38 +49,14 @@ jobs:
     runs-on:                 ubuntu-latest
 
     steps:
-      # checkout `main`.
-      - name:                Checkout
-        id:                  checkout
-        uses:                actions/checkout@v3
+      - name:              Release version
+        id:                  release-version
+        uses:                tomtom-international/commisery-action/bump@v1
         with:
-          fetch-depth:       0
           token:             ${{ secrets.GITHUB_TOKEN }}
-          ref:               main
-      # create the changelog.
-      - name:                Changelog
-        id:                  changelog
-        uses:                TriPSs/conventional-changelog-action@v3
-        with:
-          git-message:       "chore(release): relase \'v{version}\'"
-          git-user-name:     "github-actions"
-          git-user-email:    "41898282+github-actions[bot]@users.noreply.github.com"
-          github-token:      ${{ secrets.GITHUB_TOKEN }}
-          tag-prefix:        ''
-          output-file:       'false'
-          skip-commit:       'true'
-          skip-version-file: 'true'
-      # release the new version.
-      - name:                Release
-        id:                  release
-        uses:                actions/create-release@v1
-        if:                  ${{ steps.changelog.outputs.skipped == 'false' }}
-        env:
-          GITHUB_TOKEN:      ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name:          ${{ steps.changelog.outputs.tag }}
-          release_name:      v${{ steps.changelog.outputs.tag }}
-          body:              ${{ steps.changelog.outputs.clean_changelog }}
+          create-release:    true
+          create-tag:        true
+          version-prefix:    v
 
   # create docs.
   docs:

--- a/Sources/DropView/Views/DropView.swift
+++ b/Sources/DropView/Views/DropView.swift
@@ -46,25 +46,40 @@ public struct DropView<Content: View, Leading: View, Trailing: View>: View {
     /// The underlying view.
     public var body: some View {
         HStack(spacing: horizontalSpacing) {
-            leading
-                .fixedSize()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: accessoryWidth, alignment: .leading)
-                .background(GeometryReader {
-                    Color.clear.preference(key: NewDropViewWidthPreferenceKey.self, value: [$0.size.width])
-                })
+            if case .default = balancing,
+               leading is EmptyView,
+               !(trailing is EmptyView) {
+                // Add balancing when there's no `leading`.
+                Color.clear.frame(width: accessoryWidth ?? 0)
+            } else {
+                leading
+                    .fixedSize()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: accessoryWidth, alignment: .leading)
+                    .background(GeometryReader {
+                        Color.clear.preference(key: NewDropViewWidthPreferenceKey.self, value: [$0.size.width])
+                    })
+            }
             // `content` should be automatically
             // displayed vertically.
             VStack(spacing: verticalSpacing) {
                 content.fixedSize()
             }.multilineTextAlignment(.center)
-            trailing
-                .fixedSize()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: accessoryWidth, alignment: .trailing)
-                .background(GeometryReader {
-                    Color.clear.preference(key: NewDropViewWidthPreferenceKey.self, value: [$0.size.width])
-                })
+            
+            if case .default = balancing,
+               !(leading is EmptyView),
+               trailing is EmptyView {
+                // Add balancing when there's no `trailing`.
+                Color.clear.frame(width: accessoryWidth ?? 0)
+            } else {
+                trailing
+                    .fixedSize()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: accessoryWidth, alignment: .trailing)
+                    .background(GeometryReader {
+                        Color.clear.preference(key: NewDropViewWidthPreferenceKey.self, value: [$0.size.width])
+                    })
+            }
         }
         .fixedSize(horizontal: false, vertical: true)
         // Handle changes to accessory widths.
@@ -128,11 +143,6 @@ struct Previews_DropView_Previews: PreviewProvider { // swiftlint:disable:this t
                 .imageScale(.large)
                 .font(.headline)
                 .foregroundColor(.secondary)
-        } trailing: {
-            Image(systemName: "star.circle.fill")
-                .resizable()
-                .frame(width: 40, height: 40)
-                .foregroundColor(.accentColor)
         }
         .padding(40)
         .previewLayout(.sizeThatFits)


### PR DESCRIPTION
### Fixed
A regression in `1.0.0` meant if you were only adding one between `leading` and `trailing`, you would not get `content` centered correctly.

### Other
`Pull request` Action now triggers less often, and `Push` uses a new release generator.
